### PR TITLE
AWS quickstart conf should have deployment=aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The KVM provider is currently blocked from deploying OCP by issue https://github
 [global]
 openshift_version = 3.6
 openshift_type = origin
-deployment = kvm
+deployment = aws
 ssh_key_file = /home/<YOUR_USER>/.ssh/id_rsa
 deploy_catalog = true
 


### PR DESCRIPTION
Without `deployment=aws` the parser crashes due to the try/catch skipping `debug` after being unable to find `kvm`