### PR TITLE
Add port 443 to allow registry console access

### DIFF
--- a/ansible/aws-hypervisor/tasks/ec2_security.yml
+++ b/ansible/aws-hypervisor/tasks/ec2_security.yml
@@ -19,6 +19,10 @@
         from_port: 8443
         to_port: 8443
         cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 443
+        to_port: 443
+        cidr_ip: 0.0.0.0/0
 
 - name: create ssh key
   ec2_key:


### PR DESCRIPTION
Port 443 needs to be open in order to access  registry console.